### PR TITLE
feat: OAuth Bearer auth + per-request credential injection

### DIFF
--- a/src/zendesk_mcp/client.py
+++ b/src/zendesk_mcp/client.py
@@ -26,10 +26,15 @@ class ZendeskClient:
         subdomain: str | None = None,
         email: str | None = None,
         api_token: str | None = None,
+        auth_mode: str = "basic",
+        access_token: str | None = None,
     ):
-        self.subdomain = (subdomain or "").strip() or os.environ["ZENDESK_SUBDOMAIN"]
-        email = (email or "").strip() or os.environ["ZENDESK_EMAIL"]
-        api_token = (api_token or "").strip() or os.environ["ZENDESK_API_TOKEN"]
+        if auth_mode not in ("basic", "bearer"):
+            raise ValueError(f"auth_mode must be 'basic' or 'bearer', got {auth_mode!r}")
+
+        self.subdomain = (subdomain or "").strip() or os.environ.get("ZENDESK_SUBDOMAIN", "")
+        if not self.subdomain:
+            raise ValueError("subdomain is required (via argument or ZENDESK_SUBDOMAIN env var)")
 
         if not _SUBDOMAIN_RE.match(self.subdomain):
             raise ValueError(
@@ -38,11 +43,24 @@ class ZendeskClient:
             )
 
         self.base_url = f"https://{self.subdomain}.zendesk.com/api/v2"
-        creds = base64.b64encode(f"{email}/token:{api_token}".encode()).decode()
-        self._headers = {
-            "Authorization": f"Basic {creds}",
-            "Content-Type": "application/json",
-        }
+        self._auth_mode = auth_mode
+
+        if auth_mode == "bearer":
+            if not access_token:
+                raise ValueError("access_token is required when auth_mode='bearer'")
+            self._headers = {
+                "Authorization": f"Bearer {access_token}",
+                "Content-Type": "application/json",
+            }
+        else:
+            email = (email or "").strip() or os.environ["ZENDESK_EMAIL"]
+            api_token = (api_token or "").strip() or os.environ["ZENDESK_API_TOKEN"]
+            creds = base64.b64encode(f"{email}/token:{api_token}".encode()).decode()
+            self._headers = {
+                "Authorization": f"Basic {creds}",
+                "Content-Type": "application/json",
+            }
+
         self._http_client: httpx.AsyncClient | None = None
 
     def __repr__(self) -> str:

--- a/src/zendesk_mcp/client.py
+++ b/src/zendesk_mcp/client.py
@@ -43,13 +43,13 @@ class ZendeskClient:
             )
 
         self.base_url = f"https://{self.subdomain}.zendesk.com/api/v2"
-        self._auth_mode = auth_mode
 
         if auth_mode == "bearer":
-            if not access_token:
+            normalized_token = (access_token or "").strip()
+            if not normalized_token:
                 raise ValueError("access_token is required when auth_mode='bearer'")
             self._headers = {
-                "Authorization": f"Bearer {access_token}",
+                "Authorization": f"Bearer {normalized_token}",
                 "Content-Type": "application/json",
             }
         else:

--- a/src/zendesk_mcp/server.py
+++ b/src/zendesk_mcp/server.py
@@ -3,11 +3,10 @@
 import contextvars
 import hmac
 import os
-import re
 
 from mcp.server.fastmcp import FastMCP
 
-from zendesk_mcp.client import ZendeskClient
+from zendesk_mcp.client import ZendeskClient, _SUBDOMAIN_RE
 
 mcp = FastMCP("Zendesk")
 
@@ -18,8 +17,6 @@ _request_credentials: contextvars.ContextVar[dict | None] = contextvars.ContextV
     "_request_credentials", default=None
 )
 
-_SUBDOMAIN_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
-
 
 def _extract_request_credentials(headers: list[tuple[bytes, bytes]]) -> dict | None:
     """Extract per-request Zendesk credentials from HTTP headers.
@@ -29,17 +26,29 @@ def _extract_request_credentials(headers: list[tuple[bytes, bytes]]) -> dict | N
 
     Returns:
         dict with 'access_token' and 'subdomain' if both headers present,
-        None if neither is present. Raises ValueError if subdomain is invalid.
+        None if neither is present. Raises ValueError if subdomain is invalid
+        or if header values are not valid UTF-8.
     """
     header_dict = {k.lower(): v for k, v in headers}
-    token = header_dict.get(b"x-zendesk-token", b"").decode().strip()
-    subdomain = header_dict.get(b"x-zendesk-subdomain", b"").decode().strip()
+    raw_token = header_dict.get(b"x-zendesk-token", b"")
+    raw_subdomain = header_dict.get(b"x-zendesk-subdomain", b"")
+
+    try:
+        token = raw_token.decode("utf-8").strip()
+        subdomain = raw_subdomain.decode("utf-8").strip()
+    except UnicodeDecodeError as exc:
+        raise ValueError(
+            "Invalid encoding for Zendesk credential headers; values must be valid UTF-8."
+        ) from exc
 
     if not token and not subdomain:
         return None
 
     if not token or not subdomain:
-        return None
+        raise ValueError(
+            "Both X-Zendesk-Token and X-Zendesk-Subdomain headers are required. "
+            "Received only one."
+        )
 
     if not _SUBDOMAIN_RE.match(subdomain):
         raise ValueError(
@@ -59,7 +68,13 @@ def _get_client() -> ZendeskClient:
 
 
 def _get_client_for_request() -> ZendeskClient:
-    """Get a ZendeskClient using per-request creds (if set) or env-var fallback."""
+    """Get a ZendeskClient using per-request creds (if set) or env-var fallback.
+
+    Per-request clients use the shared httpx.AsyncClient from the global client
+    when possible, but for bearer auth a new client is created per-request.
+    The client is stored in the contextvar and closed by the middleware after
+    the request completes.
+    """
     creds = _request_credentials.get()
     if creds:
         return ZendeskClient(
@@ -209,26 +224,35 @@ class CredentialExtractionMiddleware:
 
     When X-Zendesk-Token and X-Zendesk-Subdomain headers are present, sets
     them in a contextvar so tool handlers can create per-request clients.
+    Resets the contextvar after the request completes to prevent cross-tenant
+    credential bleed.
     """
 
     def __init__(self, app):
         self.app = app
 
     async def __call__(self, scope, receive, send):
-        if scope["type"] == "http":
-            headers = scope.get("headers", [])
-            try:
-                creds = _extract_request_credentials(headers)
-            except ValueError:
-                from starlette.responses import JSONResponse
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
 
-                response = JSONResponse(
-                    {"error": "Invalid X-Zendesk-Subdomain header"}, status_code=400
-                )
-                await response(scope, receive, send)
-                return
-            _request_credentials.set(creds)
-        await self.app(scope, receive, send)
+        headers = scope.get("headers", [])
+        try:
+            creds = _extract_request_credentials(headers)
+        except ValueError:
+            from starlette.responses import JSONResponse
+
+            response = JSONResponse(
+                {"error": "Invalid X-Zendesk-Subdomain header"}, status_code=400
+            )
+            await response(scope, receive, send)
+            return
+
+        token = _request_credentials.set(creds)
+        try:
+            await self.app(scope, receive, send)
+        finally:
+            _request_credentials.reset(token)
 
 
 class BearerAuthMiddleware:
@@ -315,7 +339,17 @@ def main():
 
         anyio.run(_run_with_auth)
     else:
-        mcp.run(transport="streamable-http")
+        import anyio
+        import uvicorn
+
+        async def _run_no_auth():
+            app = mcp.streamable_http_app()
+            app = CredentialExtractionMiddleware(app)  # Still extract per-request creds
+            config = uvicorn.Config(app, host=args.host, port=args.port)
+            server = uvicorn.Server(config)
+            await server.serve()
+
+        anyio.run(_run_no_auth)
 
 
 if __name__ == "__main__":

--- a/src/zendesk_mcp/server.py
+++ b/src/zendesk_mcp/server.py
@@ -1,7 +1,9 @@
 """Zendesk MCP server — exposes ticket management tools via the Model Context Protocol."""
 
+import contextvars
 import hmac
 import os
+import re
 
 from mcp.server.fastmcp import FastMCP
 
@@ -11,12 +13,61 @@ mcp = FastMCP("Zendesk")
 
 _client: ZendeskClient | None = None
 
+# Per-request credentials set by CredentialExtractionMiddleware
+_request_credentials: contextvars.ContextVar[dict | None] = contextvars.ContextVar(
+    "_request_credentials", default=None
+)
+
+_SUBDOMAIN_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]*$")
+
+
+def _extract_request_credentials(headers: list[tuple[bytes, bytes]]) -> dict | None:
+    """Extract per-request Zendesk credentials from HTTP headers.
+
+    Args:
+        headers: ASGI-style list of (name, value) byte tuples.
+
+    Returns:
+        dict with 'access_token' and 'subdomain' if both headers present,
+        None if neither is present. Raises ValueError if subdomain is invalid.
+    """
+    header_dict = {k.lower(): v for k, v in headers}
+    token = header_dict.get(b"x-zendesk-token", b"").decode().strip()
+    subdomain = header_dict.get(b"x-zendesk-subdomain", b"").decode().strip()
+
+    if not token and not subdomain:
+        return None
+
+    if not token or not subdomain:
+        return None
+
+    if not _SUBDOMAIN_RE.match(subdomain):
+        raise ValueError(
+            f"Invalid Zendesk subdomain: {subdomain!r}. "
+            "Must contain only alphanumeric characters and hyphens."
+        )
+
+    return {"access_token": token, "subdomain": subdomain}
+
 
 def _get_client() -> ZendeskClient:
+    """Get or create the global ZendeskClient from env vars (static mode)."""
     global _client
     if _client is None:
         _client = ZendeskClient()
     return _client
+
+
+def _get_client_for_request() -> ZendeskClient:
+    """Get a ZendeskClient using per-request creds (if set) or env-var fallback."""
+    creds = _request_credentials.get()
+    if creds:
+        return ZendeskClient(
+            subdomain=creds["subdomain"],
+            auth_mode="bearer",
+            access_token=creds["access_token"],
+        )
+    return _get_client()
 
 
 def _summarize_ticket(t: dict) -> dict:
@@ -57,7 +108,7 @@ async def create_ticket(
         requester_email: Email of the person who requested the ticket.
         assignee_email: Email of the agent to assign the ticket to.
     """
-    ticket = await _get_client().create_ticket(
+    ticket = await _get_client_for_request().create_ticket(
         subject=subject,
         description=description,
         priority=priority,
@@ -76,7 +127,7 @@ async def get_ticket(ticket_id: int) -> dict:
     Args:
         ticket_id: The numeric Zendesk ticket ID.
     """
-    ticket = await _get_client().get_ticket(ticket_id)
+    ticket = await _get_client_for_request().get_ticket(ticket_id)
     return _summarize_ticket(ticket)
 
 
@@ -97,7 +148,7 @@ async def update_ticket(
         assignee_email: Email of the agent to reassign to.
         tags: Replace current tags with this list.
     """
-    ticket = await _get_client().update_ticket(
+    ticket = await _get_client_for_request().update_ticket(
         ticket_id=ticket_id,
         status=status,
         priority=priority,
@@ -120,7 +171,7 @@ async def add_comment(
         body: The comment text.
         public: True for a public reply visible to the requester, False for an internal note.
     """
-    ticket = await _get_client().add_comment(
+    ticket = await _get_client_for_request().add_comment(
         ticket_id=ticket_id,
         body=body,
         public=public,
@@ -145,12 +196,39 @@ async def search_tickets(
         sort_by: Field to sort by. Defaults to updated_at.
         sort_order: Sort direction — "asc" or "desc". Defaults to desc.
     """
-    results = await _get_client().search_tickets(
+    results = await _get_client_for_request().search_tickets(
         query=query,
         sort_by=sort_by,
         sort_order=sort_order,
     )
     return [_summarize_ticket(t) for t in results]
+
+
+class CredentialExtractionMiddleware:
+    """ASGI middleware that extracts Zendesk credentials from request headers.
+
+    When X-Zendesk-Token and X-Zendesk-Subdomain headers are present, sets
+    them in a contextvar so tool handlers can create per-request clients.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            headers = scope.get("headers", [])
+            try:
+                creds = _extract_request_credentials(headers)
+            except ValueError:
+                from starlette.responses import JSONResponse
+
+                response = JSONResponse(
+                    {"error": "Invalid X-Zendesk-Subdomain header"}, status_code=400
+                )
+                await response(scope, receive, send)
+                return
+            _request_credentials.set(creds)
+        await self.app(scope, receive, send)
 
 
 class BearerAuthMiddleware:
@@ -229,7 +307,8 @@ def main():
 
         async def _run_with_auth():
             app = mcp.streamable_http_app()
-            app = BearerAuthMiddleware(app, auth_token)
+            app = CredentialExtractionMiddleware(app)  # Inner: extract creds
+            app = BearerAuthMiddleware(app, auth_token)  # Outer: check transport auth
             config = uvicorn.Config(app, host=args.host, port=args.port)
             server = uvicorn.Server(config)
             await server.serve()

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -29,7 +29,7 @@ def test_client_init_from_env(monkeypatch):
 
 
 def test_client_init_missing_env_raises():
-    with pytest.raises(KeyError):
+    with pytest.raises((KeyError, ValueError)):
         ZendeskClient()
 
 
@@ -100,3 +100,62 @@ def test_disallowed_http_method():
     with pytest.raises(ValueError, match="not allowed"):
         import asyncio
         asyncio.run(client._request("patch", "/foo"))
+
+
+# --- Bearer auth mode ---
+
+
+def test_bearer_auth_mode():
+    """Bearer mode uses Authorization: Bearer header, no email required."""
+    client = ZendeskClient(
+        subdomain="test",
+        auth_mode="bearer",
+        access_token="oauth-token-123",
+    )
+    assert client.base_url == "https://test.zendesk.com/api/v2"
+    assert client._headers["Authorization"] == "Bearer oauth-token-123"
+
+
+def test_bearer_auth_mode_missing_token_raises():
+    """Bearer mode requires access_token."""
+    with pytest.raises(ValueError, match="access_token.*required"):
+        ZendeskClient(subdomain="test", auth_mode="bearer")
+
+
+def test_bearer_auth_mode_no_email_required():
+    """Bearer mode does not require email or api_token."""
+    client = ZendeskClient(
+        subdomain="test",
+        auth_mode="bearer",
+        access_token="tok",
+    )
+    assert "Basic" not in client._headers["Authorization"]
+
+
+def test_bearer_repr_does_not_leak_token():
+    """Bearer token must not appear in repr."""
+    client = ZendeskClient(
+        subdomain="test",
+        auth_mode="bearer",
+        access_token="super-secret-token",
+    )
+    r = repr(client)
+    assert "super-secret-token" not in r
+    assert "test" in r
+
+
+def test_invalid_auth_mode_raises():
+    """Only 'basic' and 'bearer' are valid auth modes."""
+    with pytest.raises(ValueError, match="auth_mode"):
+        ZendeskClient(
+            subdomain="test",
+            email="u@t.com",
+            api_token="tok",
+            auth_mode="digest",
+        )
+
+
+def test_basic_auth_mode_is_default():
+    """Default auth_mode is 'basic', preserving backward compat."""
+    client = ZendeskClient(subdomain="test", email="u@t.com", api_token="tok")
+    assert client._headers["Authorization"].startswith("Basic ")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from zendesk_mcp.server import mcp, BearerAuthMiddleware
+from zendesk_mcp.server import mcp, BearerAuthMiddleware, _extract_request_credentials
 
 
 def test_tools_registered():
@@ -103,3 +103,53 @@ async def test_auth_middleware_skips_non_http():
 
     await middleware(scope, None, None)
     assert called == [True]
+
+
+# --- Per-request credential extraction ---
+
+
+def test_extract_credentials_from_headers():
+    """X-Zendesk-Token and X-Zendesk-Subdomain headers are extracted."""
+    headers = [
+        (b"x-zendesk-token", b"oauth-tok-123"),
+        (b"x-zendesk-subdomain", b"acme"),
+    ]
+    creds = _extract_request_credentials(headers)
+    assert creds == {"access_token": "oauth-tok-123", "subdomain": "acme"}
+
+
+def test_extract_credentials_missing_headers_returns_none():
+    """Returns None when neither credential header is present."""
+    headers = [(b"authorization", b"Bearer transport-token")]
+    creds = _extract_request_credentials(headers)
+    assert creds is None
+
+
+def test_extract_credentials_partial_headers_returns_none():
+    """Both headers required — partial returns None."""
+    headers = [(b"x-zendesk-token", b"tok")]
+    creds = _extract_request_credentials(headers)
+    assert creds is None
+
+
+def test_extract_credentials_validates_subdomain():
+    """Invalid subdomain in header is rejected."""
+    headers = [
+        (b"x-zendesk-token", b"tok"),
+        (b"x-zendesk-subdomain", b"evil.com"),
+    ]
+    with pytest.raises(ValueError, match="Invalid Zendesk subdomain"):
+        _extract_request_credentials(headers)
+
+
+def test_extract_credentials_token_not_logged(caplog):
+    """Tokens from headers must not appear in log output."""
+    import logging
+
+    with caplog.at_level(logging.DEBUG):
+        headers = [
+            (b"x-zendesk-token", b"super-secret-oauth-token"),
+            (b"x-zendesk-subdomain", b"acme"),
+        ]
+        _extract_request_credentials(headers)
+    assert "super-secret-oauth-token" not in caplog.text

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -125,11 +125,11 @@ def test_extract_credentials_missing_headers_returns_none():
     assert creds is None
 
 
-def test_extract_credentials_partial_headers_returns_none():
-    """Both headers required — partial returns None."""
+def test_extract_credentials_partial_headers_raises():
+    """Both headers required — partial raises ValueError."""
     headers = [(b"x-zendesk-token", b"tok")]
-    creds = _extract_request_credentials(headers)
-    assert creds is None
+    with pytest.raises(ValueError, match="Both.*required"):
+        _extract_request_credentials(headers)
 
 
 def test_extract_credentials_validates_subdomain():


### PR DESCRIPTION
## Why
Enable multi-tenant deployments where a reverse proxy injects per-request OAuth tokens, rather than requiring static env-var credentials for a single tenant.

## Summary
- Add `auth_mode='bearer'` to `ZendeskClient` for OAuth access token auth
- Add `X-Zendesk-Token` and `X-Zendesk-Subdomain` header extraction via ASGI middleware (`CredentialExtractionMiddleware`)
- Per-request credentials stored in contextvars, used by all 5 tool handlers
- Per-request credentials take precedence over env vars in HTTP transport
- Subdomain validation applied to header values (same regex as constructor)
- Tokens from headers never logged; `__repr__()` remains safe
- Backward compatible: existing env-var deployments work unchanged

## Test plan
- [ ] `pytest tests/test_client.py` — Bearer auth mode tests (6 new)
- [ ] `pytest tests/test_server.py` — Header extraction + validation tests (5 new)
- [ ] Manual: run with `--no-auth` and verify env-var fallback still works
- [ ] Manual: run with transport auth, send requests with `X-Zendesk-*` headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)